### PR TITLE
making sure there is an empty markdown line between consecutive markdown texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [2-alpha80] - unreleased
 - avoiding the iframe when serving the page (simplifies URL handling, etc.)
 - slight changes in styling
+- making sure there is an empty markdown line between markdown texts of consecutive comments
 
 ## [2-alpha79] - 2024-02-08
 - handling element max height in markdown

--- a/src/scicloj/clay/v2/read.clj
+++ b/src/scicloj/clay/v2/read.clj
@@ -79,7 +79,7 @@
                               (drop 2))))
    :code (->> comment-blocks-sorted-by-region
               (map :code)
-              (string/join "\n"))
+              (string/join "\n\n"))
    :comment? true})
 
 (defn ->notes [code]


### PR DESCRIPTION
fixing #56 