### PR TITLE
Add support for plotly layout and config

### DIFF
--- a/notebooks/index.clj
+++ b/notebooks/index.clj
@@ -748,7 +748,8 @@ nested-structure-1
            :opacity 0.5
            :line {:width 5}
            :marker {:size 4
-                    :colorscale :Viridis}}]})
+                    :colorscale :Viridis}}]
+   :layout {:title "Plotly example"}})
 
 (kind/plotly
  plotly-example)

--- a/src/scicloj/clay/v2/item.clj
+++ b/src/scicloj/clay/v2/item.clj
@@ -153,18 +153,18 @@
 
 
 (defn plotly [{:as context
-               :keys [value]}]
+               {:keys [data layout config]
+                :or {layout {}
+                     config {}}} :value}]
   {:hiccup [:div
             {:style (extract-style context)}
             [:script
-             (->> value
-                  charred/write-json-str
-                  (format
-                   "
-Plotly.newPlot(document.currentScript.parentElement,
- %s['data']
-);
-"))]]
+             (format
+              "Plotly.newPlot(document.currentScript.parentElement,
+              %s, %s, %s);"
+              (charred/write-json-str data)
+              (charred/write-json-str layout)
+              (charred/write-json-str config))]]
    :deps [:plotly]})
 
 


### PR DESCRIPTION
Hello everyone! :wave:

[`Plotly.newPlot(graphDiv, data, layout, config)`](https://plotly.com/javascript/plotlyjs-function-reference/#plotlynewplot) takes 2 optional arguments `layout` and `config` but it wasn't possible to pass them from Clay before this change.

Now layout and config can be optionally specified so more plotly features are supported e.g. adding a title to a chart: 
![Screenshot 2024-03-16 at 10 46 09](https://github.com/scicloj/clay/assets/4920654/bd8fc01a-2c8a-41ee-a10e-a0944daf52bf)

PS. I've just discovered Clay and it has been awesome! Thank you so much for it!