### PR TITLE
Add classes to elements that have styling applied to faciliate custom styles

### DIFF
--- a/src/scicloj/clay/v2/prepare.clj
+++ b/src/scicloj/clay/v2/prepare.clj
@@ -315,7 +315,7 @@
                                                     (string/join " ")
                                                     item/printed-clojure)
                                                context))))
-                        (into [:div
+                        (into [:div.clay-map
                                {:style {:margin-left "10%"
                                         :width "110%"}}]))
                    (structure-mark-hiccup "}")]
@@ -345,8 +345,8 @@
                   (structure-mark-hiccup open-mark)
                   (->> prepared-parts
                        (map #(item->hiccup % context))
-                       (into [:div {:style {:margin-left "10%"
-                                            :width "110%"}}]))
+                       (into [:div.clay-sequential {:style {:margin-left "10%"
+                                                            :width "110%"}}]))
                   (structure-mark-hiccup close-mark)]
          :deps (->> prepared-parts
                     (mapcat :deps)


### PR DESCRIPTION
The current 110% width that gets applied to certain nested values can break the UI for pages rendered with quarto because of its mini TOC on the right-hand side, like this for example:

<img width="1120" alt="image" src="https://github.com/scicloj/clay/assets/11531673/f8d83491-ee34-4a30-abd8-a87dc9eb6f24">

This PR just adds some classes to the relevant divs so that over-riding these styles is easier for users. Another solution might be to also remove the 110% width style. Note that it is also currently possible to fix it using CSS like this:

```css
div:has(> .clay-dataset) {
  width: unset !important;
}
```
(subsituting `.clay-dataset` for whatever child class is relevant in the specific notebook one is dealing with). This PR would make it generically possible though and not dependent on the order of blocks in a given notebook.