### PR TITLE
Regression fix: make *stop-server! a fn for stopping the server

### DIFF
--- a/src/scicloj/clay/v2/server.clj
+++ b/src/scicloj/clay/v2/server.clj
@@ -186,9 +186,9 @@
 (defn open! []
   (when-not @*stop-server!
     (let [port (get-free-port)
-          server (core-http-server port)]
+          stop-server (core-http-server port)]
       (server.state/set-port! port)
-      (reset! *stop-server! port)
+      (reset! *stop-server! stop-server)
       (println "serving Clay at" (port->url port))
       (browse!))))
 


### PR DESCRIPTION
It was originally a fn for stopping the server, and was changed to a port number, presumably by accident. It is not used as a number anywhere and it is used as a function in one place, see search results below:

src/scicloj/clay/v2/server.clj
166  (defonce *stop-server! (atom nil))
187    (when-not @*stop-server!
189            stop-server (core-http-server port)]
191        (reset! *stop-server! stop-server)
214    (when-let [s @*stop-server!]
216    (reset! *stop-server! nil))