### PR TITLE
Live reload fixes 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [2-beta18] - unreleased
-- live-reload support - thanks, @whatacold
-- Emmy-Viewers support - WIP
+- live-reload support - experimental - thanks, @whatacold
+- Emmy-Viewers support - experimental
 
 ## [2-beta17] - 2024-09-30
 - removed unused require (PR #162) - thanks, @schneiderlin, @mchughs

--- a/notebooks/index.clj
+++ b/notebooks/index.clj
@@ -452,9 +452,9 @@
 ;; | `:base-source-path` | where to find `:source-path` | `"notebooks"` |
 ;; | `:clean-up-target-dir` | delete (!) target directory before repopulating it  | `true` |
 ;; | `:remote-repo` | linking to source | `{:git-url "https://github.com/scicloj/clay" :branch  "main"}` |
-;; | `:hide-info-line` | hiding the source reference at the bottom | `{:hide-info-line true}` |
-;; | `:hide-ui-header` | hiding the ui info at the top | `{:hide-ui-header true}` |
-;; | `:post-process` | post-processing the resulting HTML | `{:post-process #(str/replace "#3" "4")}` |
+;; | `:hide-info-line` | hiding the source reference at the bottom | `true` |
+;; | `:hide-ui-header` | hiding the ui info at the top | `true` |
+;; | `:post-process` | post-processing the resulting HTML | `#(str/replace "#3" "4")` |
 ;; | `:live-reload` | whether to make and live reload the HTML automatically after its source file is changed | `true` |
 
 ;; When working interactively, it is helpful to render to a temporary directory that can be git ignored and discarded.

--- a/src/scicloj/clay/v2/make.clj
+++ b/src/scicloj/clay/v2/make.clj
@@ -442,7 +442,8 @@
                                                            (->abs-path file)
                                                            spec))
                                                   {})
-                                          (merge (:file-specs @*dir-watchers)))))))))
+                                          (merge (:file-specs @*dir-watchers))))))
+      [:watching-new-files new-files])))
 
 (defn make! [spec]
   (let [config (config/config)
@@ -460,9 +461,10 @@
                            first
                            (assoc :items [item/loader])
                            page/html))
-          server/update-page!)
-      (run! watch-dir single-ns-specs))
+          server/update-page!))
     [(->> single-ns-specs
           (mapv handle-single-source-spec!))
      (-> main-spec
-         handle-main-spec!)]))
+         handle-main-spec!)
+     (->> single-ns-specs
+          (mapv watch-dir))]))


### PR DESCRIPTION
@whatacold 
Here is another slight change: live reload will also work when `:show` is `false`.

Also, note I am passing every source file separately to `watch-dirs`, so that their namespace-level configuration may affect the behaviour correctly.