### PR TITLE
Watch a dir only if all of its ancestor dirs not being watched.

### DIFF
--- a/src/scicloj/clay/v2/api.clj
+++ b/src/scicloj/clay/v2/api.clj
@@ -11,7 +11,7 @@
 
 (defn stop! []
   (server/close!)
-  (live-reload/stop-watchers)
+  (live-reload/stop!)
   [:ok])
 
 (defn welcome! []

--- a/src/scicloj/clay/v2/api.clj
+++ b/src/scicloj/clay/v2/api.clj
@@ -3,6 +3,7 @@
    [clojure.string :as string]
    [clojure.test]
    [scicloj.clay.v2.config :as config]
+   [scicloj.clay.v2.live-reload :as live-reload]
    [scicloj.clay.v2.server :as server]
    [scicloj.clay.v2.make :as make]
    [scicloj.kindly.v4.api :as kindly]
@@ -10,7 +11,7 @@
 
 (defn stop! []
   (server/close!)
-  (make/stop-watchers)
+  (live-reload/stop-watchers)
   [:ok])
 
 (defn welcome! []

--- a/src/scicloj/clay/v2/live_reload.clj
+++ b/src/scicloj/clay/v2/live_reload.clj
@@ -1,0 +1,73 @@
+(ns scicloj.clay.v2.live-reload
+  (:require [clojure.java.io :as io]
+            [scicloj.clay.v2.make :as make]
+            [nextjournal.beholder :as beholder]))
+
+(defonce dir-watchers-initial {:watchers []
+                               :watched-dirs #{}
+                               :file-specs {}})
+
+(defonce *dir-watchers (atom dir-watchers-initial))
+
+(defn stop-watchers
+  "Stop all directory watchers."
+  []
+  (doseq [w (:watchers @*dir-watchers)]
+    (beholder/stop w))
+  (reset! *dir-watchers dir-watchers-initial))
+
+(defn- beholder-callback
+  "Callback function for beholder."
+  [event]
+  (let [canonical-path (str (-> event :path .toFile .getCanonicalPath))]
+    (when (and (identical? :modify (:type event))
+               (contains? (:file-specs @*dir-watchers) canonical-path))
+      (make/make! (get (:file-specs @*dir-watchers) canonical-path)))))
+
+(defn watch-dir
+  "Watch directory changes if necessary."
+  [{:as spec
+    :keys [live-reload source-path]}]
+  (when (and live-reload
+             source-path)
+    (let [->canonical-path (fn [file] (.getCanonicalPath (io/file file)))
+          watched-files (->> @*dir-watchers
+                             :file-specs
+                             keys
+                             set)
+          new-files (->> source-path
+                         (#(if (vector? %) % [%]))
+                         ;; make sure all paths are canonical,
+                         ;; so that their containing directories can be properly watched by beholder
+                         (map ->canonical-path)
+                         (filter #(not (contains? watched-files %)))
+                         set)
+          new-dirs (->> new-files
+                        (map #(-> % io/file .getParent))
+                        (filter #(not (some (fn [watched-dir]
+                                              (.startsWith % watched-dir))
+                                            (:watched-dirs @*dir-watchers))))
+                        set)]
+      ;; watch dir for notebook changes
+      (when-not (empty? new-dirs)
+        (swap! *dir-watchers
+               #(assoc %
+                       :watched-dirs
+                       (into (:watched-dirs %) new-dirs)
+                       :watchers
+                       (conj (:watchers %)
+                             (apply beholder/watch
+                                    beholder-callback
+                                    new-dirs)))))
+      ;; save the spec for every file
+      (when-not (empty? new-files)
+        (swap! *dir-watchers #(assoc %
+                                     :file-specs
+                                     (->> new-files
+                                          (reduce (fn [pre-result file]
+                                                    (assoc pre-result
+                                                           file
+                                                           spec))
+                                                  {})
+                                          (merge (:file-specs @*dir-watchers))))))
+      new-files)))

--- a/src/scicloj/clay/v2/live_reload.clj
+++ b/src/scicloj/clay/v2/live_reload.clj
@@ -32,17 +32,6 @@
                            watched-dir-paths)))
        exclude-subdir-paths))
 
-(comment
-  (defn strs->paths
-    "Convert strings to paths."
-    [strs]
-    (map fs/canonicalize strs))
-
-  (defn paths->strs
-    "Convert paths to strings."
-    [paths]
-    (map str paths)))
-
 (def ^:private dir-watchers-initial {:watchers {}
                                      :file-specs {}})
 

--- a/src/scicloj/clay/v2/live_reload.clj
+++ b/src/scicloj/clay/v2/live_reload.clj
@@ -3,81 +3,92 @@
             [babashka.fs :as fs]
             [nextjournal.beholder :as beholder]))
 
-(defn- subdir-paths
+(defn subdir-paths
   "Return subdir paths of `paths1` who is a sub-directory of any `paths2`."
   [paths1 paths2]
-  (let [set1 (set paths1)
-        set2 (set paths2)]
-    (reduce (fn [result dir1]
-              (if (some #(and (not= dir1 %)
-                              (fs/starts-with? dir1 %))
-                        set2)
-                (conj result dir1)
-                result))
-            #{}
-            set1)))
+  (reduce (fn [result dir1]
+            (if (some #(and (not= dir1 %)
+                            (fs/starts-with? dir1 %))
+                      paths2)
+              (conj result dir1)
+              result))
+          #{}
+          paths1))
 
-(defn- exclude-subdirs
-  "Exclude dirs who are any sub-directories of `dirs` themselves."
-  [dirs]
-  (let [origin-dirs (set dirs)
+(defn exclude-subdir-paths
+  "Exclude paths who are sub-directories of any one of `paths`."
+  [paths]
+  (let [origin-dirs (set paths)
         to-remove (subdir-paths origin-dirs origin-dirs)]
     (set/difference origin-dirs to-remove)))
 
-(defn- dirs-to-watch
+(defn dirs-to-watch
   "Find out directories of files in `file-paths` to watch."
-  [watched-dirs file-paths]
+  [watched-dir-paths file-paths]
   (->> file-paths
        (map fs/parent)
        (filter #(not (some (fn [watched-dir]
                              (fs/starts-with? % watched-dir))
-                           watched-dirs)))
-       exclude-subdirs))
+                           watched-dir-paths)))
+       exclude-subdir-paths))
 
-(defn- strs->paths
-  "Convert strings to paths."
-  [strs]
-  (map fs/canonicalize strs))
+(comment
+  (defn strs->paths
+    "Convert strings to paths."
+    [strs]
+    (map fs/canonicalize strs))
 
-(defn- paths->strs
-  "Convert paths to strings."
-  [paths]
-  (map str paths))
+  (defn paths->strs
+    "Convert paths to strings."
+    [paths]
+    (map str paths)))
 
 (def ^:private dir-watchers-initial {:watchers {}
                                      :file-specs {}})
 
 (def ^:private *dir-watchers (atom dir-watchers-initial))
 
-(defn- beholder-callback!
+(defn beholder-callback!
   "Return a callback function for beholder."
   [make-fn]
   (fn [event]
-    (let [canonical-path (-> event :path fs/canonicalize str)]
-      (when (and (identical? :modify (:type event))
-                 (contains? (:file-specs @*dir-watchers) canonical-path))
-        (make-fn (get (:file-specs @*dir-watchers) canonical-path))))))
+    (let [canonical-path (-> event :path fs/canonicalize)
+          spec (get (:file-specs @*dir-watchers) canonical-path)]
+      (when (and spec (identical? :modify (:type event)))
+        (make-fn spec)))))
 
-(defn- start-watching-dirs!
+(defn watched-dirs!
+  "Get all watched dirs as paths."
+  []
+  (->> @*dir-watchers :watchers keys set))
+
+(defn watched-files!
+  "Get all watched dirs as paths."
+  []
+  (->> @*dir-watchers :file-specs keys set))
+
+(defn start-watching-dirs!
   "Start watching file changes in all `dirs`, with callback `cb`."
   [dirs cb]
   (doseq [dir dirs]
-    (swap! *dir-watchers
-           #(assoc %
-                   :watchers
-                   (assoc (:watchers %)
-                          dir
-                          (beholder/watch cb dir))))))
+    (when-not (contains? (watched-dirs!) dir)
+      (swap! *dir-watchers
+             #(assoc %
+                     :watchers
+                     (assoc (:watchers %)
+                            dir
+                            (beholder/watch cb (str dir))))))))
 
-(defn- stop-watching-dirs!
+(defn stop-watching-dirs!
   "Stop watching file changes in all `dirs`."
   [dirs]
   (doseq [dir dirs]
-    (beholder/stop (-> @*dir-watchers :watchers (get dir)))
-    (swap! *dir-watchers
-           #(assoc %
-                   :watchers
-                   (dissoc (:watchers %) dir)))))
+    (when-let [watcher (-> @*dir-watchers :watchers (get dir))]
+      (beholder/stop watcher)
+      (swap! *dir-watchers
+             #(assoc %
+                     :watchers
+                     (dissoc (:watchers %) dir))))))
 
 (defn start!
   "Watch directory changes for `source-path`."
@@ -85,33 +96,29 @@
             :keys [live-reload source-path]}]
   (when (and live-reload
              source-path)
-    (let [watched-files (->> @*dir-watchers
-                             :file-specs
-                             keys
-                             set)
-          new-files (->> source-path
+    (let [new-files (->> source-path
                          (#(if (vector? %) % [%]))
                          ;; make sure all paths are canonical,
                          ;; so that their containing directories can be properly watched by beholder
                          (map fs/canonicalize)
-                         (filter #(not (contains? watched-files %)))
+                         (filter #(not (contains? (watched-files!) %)))
                          set)
-          new-dirs (dirs-to-watch (strs->paths (keys (:watchers @*dir-watchers)))
+          new-dirs (dirs-to-watch (watched-dirs!)
                                   new-files)]
       ;; stop watching dirs now having been subdirs.
-      (when-let [dirs-to-stop (subdir-paths (strs->paths (keys (:watchers @*dir-watchers)))
-                                       new-dirs)]
-        (stop-watching-dirs! (paths->strs dirs-to-stop)))
+      (when-let [dirs-to-stop (subdir-paths (watched-dirs!)
+                                            new-dirs)]
+        (stop-watching-dirs! dirs-to-stop))
       ;; watch new dirs for notebook changes
       (when-not (empty? new-dirs)
-        (start-watching-dirs! (paths->strs new-dirs) (beholder-callback! make-fn)))
+        (start-watching-dirs! new-dirs (beholder-callback! make-fn)))
       ;; save the spec for every file
       (when-not (empty? new-files)
         (swap! *dir-watchers #(assoc %
                                      :file-specs
                                      (->> new-files
                                           (reduce (fn [result file]
-                                                    (assoc result (str file) spec))
+                                                    (assoc result file spec))
                                                   {})
                                           (merge (:file-specs @*dir-watchers))))))
       new-files)))
@@ -119,21 +126,5 @@
 (defn stop!
   "Stop all directory watchers."
   []
-  (stop-watching-dirs! (-> @*dir-watchers :watchers keys))
+  (stop-watching-dirs! (watched-dirs!))
   (reset! *dir-watchers dir-watchers-initial))
-
-(comment
-  (strs->paths ["/tmp/a/" "/tmp/b/"])
-  (paths->strs (strs->paths ["/tmp/a/" "/tmp/b/"]))
-  (subdir-paths (map fs/canonicalize '("/tmp/foo/a/" "/tmp/foo/a/b/" "/tmp/bar/a/" "/tmp/baz/a/"))
-                (map fs/canonicalize '("/tmp/foo/" "/tmp/bar/")))
-  (exclude-subdirs (map fs/canonicalize ["/tmp/a/" "/tmp/b/" "/tmp/a/foo/" "/tmp/a/bar/"]))
-  (dirs-to-watch (map fs/canonicalize ["/tmp/foo/" "/tmp/bar/"])
-                 (map fs/canonicalize ["/tmp/foo/a.clj" "/tmp/bar/b.clj"
-                                       "/tmp/c.clj" "/tmp/d/d.clj"]))
-  @*dir-watchers
-  (:watchers @*dir-watchers)
-  (keys (:file-specs @*dir-watchers))
-  (start-watching-dirs! ["/tmp/a/" "/tmp/b/"] prn)
-  (stop-watching-dirs! ["/tmp/a/" "/tmp/b/"])
-  )

--- a/src/scicloj/clay/v2/make.clj
+++ b/src/scicloj/clay/v2/make.clj
@@ -415,7 +415,7 @@
      (-> main-spec
          handle-main-spec!)
      (->> single-ns-specs
-          (map live-reload/watch-dir)
+          (map #(live-reload/start! make! %))
           (reduce into #{})
           (vector :watching-new-files))]))
 

--- a/test/scicloj/clay/v2/live_reload_test.clj
+++ b/test/scicloj/clay/v2/live_reload_test.clj
@@ -1,0 +1,104 @@
+(ns scicloj.clay.v2.live-reload-test
+  (:require [scicloj.clay.v2.live-reload :as lr]
+            [babashka.fs :as fs]
+            [clojure.test :refer [deftest is]]))
+
+(deftest subdir-paths-test
+  (fs/with-temp-dir [test-dir]
+    (is (= #{(fs/path test-dir "foo" "a")
+             (fs/path test-dir "foo" "a" "b")
+             (fs/path test-dir "bar" "a")}
+           (lr/subdir-paths [(fs/path test-dir "foo" "a")
+                             (fs/path test-dir "foo" "a" "b")
+                             (fs/path test-dir "bar" "a")
+                             (fs/path test-dir "baz" "a")]
+                            [(fs/path test-dir "foo")
+                             (fs/path test-dir "bar")])))))
+
+(deftest exclude-subdir-paths-test
+  (fs/with-temp-dir [test-dir]
+    (is (= #{(fs/path test-dir "foo")
+             (fs/path test-dir "bar")}
+           (lr/exclude-subdir-paths [(fs/path test-dir "foo")
+                                     (fs/path test-dir "bar")])))
+    (is (= #{(fs/path test-dir "foo")
+             (fs/path test-dir "bar")}
+           (lr/exclude-subdir-paths [(fs/path test-dir "foo")
+                                     (fs/path test-dir "foo" "a")
+                                     (fs/path test-dir "bar")
+                                     (fs/path test-dir "bar" "b")])))))
+
+(deftest dirs-to-watch-test
+  (fs/with-temp-dir [test-dir]
+    (is (= #{(fs/path test-dir "bar")}
+           (lr/dirs-to-watch #{(fs/path test-dir "foo")}
+                             #{(fs/path test-dir "foo" "a.clj")
+                               (fs/path test-dir "foo" "b" "a.clj")
+                               (fs/path test-dir "bar" "a.clj")
+                               (fs/path test-dir "bar" "b" "a.clj")})))))
+
+(defn mock-make-fn [spec]
+  (println "mock-make-fn: " spec))
+
+(defn create-dirs [dirs]
+  (doseq [dir dirs]
+    (fs/create-dirs dir)))
+
+(deftest start-stop-watching-dirs!-test
+  (fs/with-temp-dir [test-dir]
+    (let [dirs [(fs/path test-dir "foo")
+                (fs/path test-dir "foo")
+                (fs/path test-dir "bar")]]
+      (create-dirs dirs)
+      (lr/start-watching-dirs! dirs mock-make-fn)
+      (is (= #{(fs/path test-dir "foo")
+               (fs/path test-dir "bar")}
+             (lr/watched-dirs!))
+          "watch a dir exactly once")
+      (lr/stop-watching-dirs! dirs)
+      (is (= #{}
+             (lr/watched-dirs!))
+          "all being stopped"))))
+
+(deftest start!-stop!-test
+  (fs/with-temp-dir [test-dir]
+    (let [file1 (fs/path test-dir "foo" "bar" "a.clj")]
+      (fs/create-dirs (fs/parent file1))
+      (lr/start! mock-make-fn {:live-reload true
+                               :source-path (str file1)})
+      (is (= #{file1}
+             (lr/watched-files!))
+          "watch first file")
+      (is (= #{(fs/parent file1)}
+             (lr/watched-dirs!))
+          "watch first dir")
+      (lr/stop!)
+      (is (= #{}
+             (lr/watched-files!)))
+      (is (= #{}
+             (lr/watched-dirs!)))
+      ;; do it again
+      (lr/start! mock-make-fn {:live-reload true
+                               :source-path (str file1)})
+      (is (= #{(fs/parent file1)}
+             (lr/watched-dirs!))
+          "watch first dir")
+      ;; make other files
+      (let [files [(fs/path test-dir "foo" "a.clj")
+                   (fs/path test-dir "foo" "baz" "a.clj")
+                   (fs/path test-dir "bar" "a.clj")]]
+        (create-dirs (map fs/parent files))
+        (lr/start! mock-make-fn {:live-reload true
+                                 :source-path (into [] (map str files))})
+        (is (= (set (apply vector file1 files))
+               (lr/watched-files!))
+            "watch files twice")
+        (is (= #{(fs/path test-dir "foo")
+                 (fs/path test-dir "bar")}
+               (lr/watched-dirs!))
+            "watch dirs twice")
+        (lr/stop!)
+        (is (= #{}
+               (lr/watched-files!)))
+        (is (= #{}
+               (lr/watched-dirs!)))))))


### PR DESCRIPTION
So that a file won't be `make!` multiple times after being changed.