### PR TITLE
fix handling :kind/test and show results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [2-beta24] - TBD
+- tests defined with `deftest` will run and show results
+
 ## [2-beta23] - 2024-11-08
 - bugfix: refreshing page appropriately to keep the main URL - by @whatacold
 


### PR DESCRIPTION
![Screen Shot 2024-11-17 at 6 03 31 PM](https://github.com/user-attachments/assets/442ee1a7-5856-402f-8cbe-f100d645fe44)

The main goal of this PR is to fix the previous behavior of throwing an exception.

This feature is not in use, but maybe now it will be more attractive.

Also it means we can run clay on a test namespace which might be interesting for some people.