### PR TITLE
,, marks support - WIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [2-beta30]
 - adds main cli: `clojure -M:dev -m scicloj.clay.v2.main`
 - launch nrepl when using live-reload from cli
+- `,,` marks support - WIP
 
 ## [2-beta29] - 2025-02-18
 - updated deps

--- a/notebooks/try_live_reload.clj
+++ b/notebooks/try_live_reload.clj
@@ -1,0 +1,23 @@
+^{:clay {:respect-marks true}}
+(ns try-live-reload
+  (:require [scicloj.kindly.v4.kind :as kind]))
+
+(comment
+  (require '[scicloj.clay.v2.api :as clay])
+  (clay/make! {:source-path "notebooks/try_live_reload.clj"
+               :live-reload true}))
+
+(kind/echarts
+ ,,
+ {:title {:text "Echarts Example"}
+  :tooltip {}
+  :legend {:data ["sales"]}
+  :xAxis {:data ["Shirts", "Cardigans", "Chiffons",
+                 "Pants", "Heels", "Socks"]}
+  :yAxis {}
+  :series [{:name "sales"
+            :type "bar"
+            :data [5 20 36
+                   10 10 20]}]})
+
+

--- a/src/scicloj/clay/v2/notebook.clj
+++ b/src/scicloj/clay/v2/notebook.clj
@@ -240,9 +240,8 @@
                                                                    :format])))
                                                 (note-to-items options)
                                                 (cond->> mark
-                                                  (#(map (fn [item]
-                                                           (assoc item :mark mark))
-                                                         %)))))
+                                                  (map (fn [item]
+                                                         (assoc item :mark mark))))))
                                 line-number (first region)
                                 varname (->var-name i line-number)
                                 test-form (cond
@@ -278,8 +277,8 @@
                    (fn [items]
                      (-> items
                          (->> (remove nil?))
-                         (cond-> some-marks
-                           (->> (#(filter :mark %))))
+                         (cond->> some-marks
+                           (filter :mark))
                          (add-info-line options)
                          doall)))
            (update :test-forms

--- a/src/scicloj/clay/v2/notebook.clj
+++ b/src/scicloj/clay/v2/notebook.clj
@@ -230,18 +230,19 @@
                           (let [{:as complete-note :keys [form kind region mark]} (complete note)
                                 test-note (test-last? complete-note)
                                 comment (:comment? complete-note)
-                                new-items (when-not test-note
-                                            (-> complete-note
-                                                (merge/deep-merge
-                                                 (-> options
-                                                     (select-keys [:base-target-path
-                                                                   :full-target-path
-                                                                   :kindly/options
-                                                                   :format])))
-                                                (note-to-items options)
-                                                (cond->> mark
-                                                  (map (fn [item]
-                                                         (assoc item :mark mark))))))
+                                new-items (if (or (not some-marks)
+                                                  mark)
+                                            (when-not test-note
+                                              (-> complete-note
+                                                  (merge/deep-merge
+                                                   (-> options
+                                                       (select-keys [:base-target-path
+                                                                     :full-target-path
+                                                                     :kindly/options
+                                                                     :format])))
+                                                  (note-to-items (merge options
+                                                                        (when mark
+                                                                          {:hide-code true}))))))
                                 line-number (first region)
                                 varname (->var-name i line-number)
                                 test-form (cond
@@ -277,8 +278,6 @@
                    (fn [items]
                      (-> items
                          (->> (remove nil?))
-                         (cond->> some-marks
-                           (filter :mark))
                          (add-info-line options)
                          doall)))
            (update :test-forms


### PR DESCRIPTION
@timothypratley 
Here is some experimental initial support to the `,,` marks support we discussed.

[#clay-dev > Idea: focus output of live-reload with &#96;,,&#96; annotations](#narrow/channel/422115-clay-dev/topic/Idea.3A.20focus.20output.20of.20live-reload.20with.20.60.2C.2C.60.20annotations) 

Currently, the logic is simple:
* When `make!`ing a namespace, if some notes have `,,` *inside* their code, then only these notes are displayed.
* This feature is active only when the config contains `:respect-marks true`.
* See `notebooks/try-live-reload.clj` for a playground.

There are a few more challenging parts of this that are not implemented yet:
* When `make!`ing a namespace, we want to evaluate only the region between:
  * the first file change or first `,,` mark
  * the last `,,` mark

* We want to also display top-level forms nearby the `,,` mark, and not only around them. E.g.:
```
(+ 1 2) 
,,
```