### PR TITLE
dont recompute config

### DIFF
--- a/src/scicloj/clay/v2/config.clj
+++ b/src/scicloj/clay/v2/config.clj
@@ -22,8 +22,9 @@
           edn/read-string))
 
 (defn add-field [config kw compute]
-  (-> config
-      (assoc kw (compute config))))
+  (if (contains? config kw)
+    config
+    (assoc config kw (compute config))))
 
 (defn config []
   (-> (default-config)


### PR DESCRIPTION
This small change allows users to pass in `full-target-path` when they care about it.
Generally, we should take existing config in preference to computing new config.