### PR TITLE
add mime-type when serving files

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,7 @@
         carocad/parcera {:mvn/version "0.11.6"}
         org.antlr/antlr4-runtime {:mvn/version "4.7.1"}
         http-kit/http-kit {:mvn/version "2.8.0"}
+        ring/ring-core {:mvn/version "1.14.1"}
         io.github.nextjournal/markdown {:mvn/version "0.6.157"}
         hiccup/hiccup {:mvn/version "2.0.0-RC4"}
         clj-commons/clj-yaml {:mvn/version "1.0.29"}

--- a/src/scicloj/clay/v2/server.clj
+++ b/src/scicloj/clay/v2/server.clj
@@ -2,12 +2,11 @@
   (:require
    [clojure.java.browse :as browse]
    [clojure.java.io :as io]
-   [clojure.string :as string]
    [hiccup.page]
    [org.httpkit.server :as httpkit]
+   [ring.util.mime-type :as mime-type]
    [scicloj.clay.v2.server.state :as server.state]
    [scicloj.clay.v2.util.time :as time]
-   [scicloj.clay.v2.item :as item]
    [clojure.string :as str]
    [cognitect.transit :as transit]
    [hiccup.core :as hiccup])
@@ -178,8 +177,8 @@
                             slurp
                             (wrap-html state))
                         f)
-             :headers (when (str/ends-with? uri ".js")
-                        {"Content-Type" "text/javascript"})
+             :headers (when-let [t (mime-type/ext-mime-type uri)]
+                        {"Content-Type" t})
              :status  200}
             (case [request-method uri]
               ;; user files have priority, otherwise serve the default from resources


### PR DESCRIPTION
Files like images do not display correctly without the mime-type. For example: (kind/hiccup [:img {:src "image.svg"}])