### PR TITLE
cursive now supports flare key title ignores extra

### DIFF
--- a/src/scicloj/clay/v2/make.clj
+++ b/src/scicloj/clay/v2/make.clj
@@ -415,9 +415,7 @@
                    :reveal false
                    :info info}]
       (if (and ide (not= browse :browser))
-        (if (= ide :cursive)
-          (tagged-literal 'cursive/html summary)
-          (tagged-literal 'flare/html summary))
+        (tagged-literal 'flare/html summary)
         summary))))
 
 

--- a/src/scicloj/clay/v2/make.clj
+++ b/src/scicloj/clay/v2/make.clj
@@ -411,6 +411,7 @@
           summary {:url (server/url)
                    :key "clay"
                    :title "Clay"
+                   :display (if single-form :inline :editor)
                    ;; TODO: Maybe we can remove 'reveal' when fixed in Calva
                    :reveal false
                    :info info}]

--- a/src/scicloj/clay/v2/make.clj
+++ b/src/scicloj/clay/v2/make.clj
@@ -416,7 +416,7 @@
                    :info info}]
       (if (and ide (not= browse :browser))
         (if (= ide :cursive)
-          (tagged-literal 'cursive/html (select-keys summary [:url]))
+          (tagged-literal 'cursive/html summary)
           (tagged-literal 'flare/html summary))
         summary))))
 


### PR DESCRIPTION
Cursive no longer throws an error for unknown keys in the html flare,
and it does support the :key and :title which make the Clay experience better.
