### PR TITLE
add aliases to config

### DIFF
--- a/notebooks/index.clj
+++ b/notebooks/index.clj
@@ -663,6 +663,9 @@
 ;; | `:sync-subdirs` | (experimental) subdirs to copy non-clojure files from | `["static"]` |
 ;; | `:sync-as-subdirs` | (experimental) keep the subdir prefix | `false` |
 ;; | `:render` | (experimental) overrides `:show` `:serve` `:browse` and `:live-reload` to `false` | `true` |
+;; | `:aliases` | (experimental) a map of alias names to configuration | `{:markdown {:format [:quarto :html]}` |
+;; | `:merge-aliases | (experimental) a vector of aliases to merge | `[:markdown]` |
+;; | `:reset-aliases | (experimental) mutably sets aliases to use | `[:markdown]` |
 
 ;; When working interactively, it is helpful to render to a temporary directory that can be git ignored and discarded.
 ;; For example: you may set `:base-target-path "temp"` at your `clay.edn` file.
@@ -670,7 +673,19 @@
 ;; in your call to `clay/make!`.
 ;; Creating a dev namespace is a good way to invoke a different configuration for publishing.
 
-;; Rendering a result is based on `clojure.pprint/pprint` behaviour. By default it will wrap anything beyond `clojure.pprint/*print-right-margin*` (default: 72) number of chars in the single line. For example `(range 100)` will be rendered as long vertical list of numbers. You can overwrite it by setting `:pprint-margin` option. When set to `nil` there won't be wrapping at all and `(range 100)` will be rendered in one horizontal list of numbers.
+;; Rendering a result is based on `clojure.pprint/pprint` behaviour.
+;; By default, it will wrap anything beyond `clojure.pprint/*print-right-margin*` (default: 72) number of chars in the single line.
+;; For example `(range 100)` will be rendered as long vertical list of numbers.
+;; You can overwrite it by setting `:pprint-margin` option.
+;; When set to `nil` there won't be wrapping at all and `(range 100)` will be rendered in one horizontal list of numbers.
+
+;; Aliases let you define reusable config fragments and selectively apply them.
+;; Add an :aliases map to your config with named configurations,
+;; then activate them using :merge-aliases (for one-time use) or :reset-aliases (to persist across invocations).
+;; For example, you might use :merge-aliases [:markdown] to generate Quarto-friendly Markdown from the REPL,
+;; or :reset-aliases [:html] in your IDE to default to full HTML rendering.
+;; Alternatively you can `(reset! scicloj.clay.v2.config/*current-aliases aliases)`.
+;; Aliases are deeply merged into the base config in order.
 
 ;; ### Namespace configuration and front matter
 

--- a/resources/clay-default.edn
+++ b/resources/clay-default.edn
@@ -7,7 +7,7 @@
  :browse true
  :live-reload false
  :run-quarto true
- :quarto {:format {:html {:toc true
+ #_#_:quarto {:format {:html {:toc true
                           :toc-depth 4
                           :theme :cosmo}
                    :revealjs {:theme :solarized

--- a/src/scicloj/clay/v2/api.clj
+++ b/src/scicloj/clay/v2/api.clj
@@ -51,5 +51,7 @@
 (defn url []
   (server/url))
 
-(defn config []
-  (config/config))
+(defn config
+  "Gathers configuration from the default, a clay.edn, and a spec if provided"
+  ([] (config/config))
+  ([spec] (config/config spec)))

--- a/src/scicloj/clay/v2/config.clj
+++ b/src/scicloj/clay/v2/config.clj
@@ -1,7 +1,11 @@
 (ns scicloj.clay.v2.config
   (:require [clojure.java.io :as io]
             [clojure.edn :as edn]
+            [scicloj.clay.v2.util.fs :as util.fs]
             [scicloj.clay.v2.util.merge :as merge]))
+
+(defonce *current-aliases
+  (atom nil))
 
 (defn slurp-when-exists [path]
   (when (-> path
@@ -25,6 +29,44 @@
   (-> config
       (assoc kw (compute config))))
 
-(defn config []
-  (-> (default-config)
-      (merge/deep-merge (maybe-user-config))))
+(defn many-configs [config]
+  (cond-> config
+          (:render config) (merge {:show        false
+                                   :serve       false
+                                   :browse      false
+                                   :live-reload false})))
+
+(defn source-paths [{:as config :keys [base-source-path source-path render]}]
+  (cond-> config
+          (and base-source-path (or (nil? source-path) (#{:all} source-path)) render)
+          (assoc :source-paths (util.fs/find-notebooks base-source-path))
+
+          (string? source-path)
+          (assoc :source-paths [source-path])))
+
+(defn apply-alias-state! [config]
+  (when (contains? config :reset-aliases)
+    (reset! *current-aliases (:reset-aliases config))))
+
+(defn merge-aliases [{:as config :keys [aliases merge-aliases]}]
+  (reduce
+    (fn [acc alias]
+      (if-let [c (get aliases alias)]
+        (merge/deep-merge acc c)
+        (do (println "Clay warning: alias" (pr-str alias) "not found in :aliases" (keys aliases))
+            acc)))
+    config
+    (or merge-aliases @*current-aliases)))
+
+(defn apply-conditionals [config]
+  (apply-alias-state! config)
+  (-> config (merge-aliases) (many-configs) (source-paths)))
+
+(defn config
+  "Gathers configuration from the default, a clay.edn, and a spec if provided"
+  ([]
+   (-> (merge/deep-merge (default-config) (maybe-user-config))
+       (apply-conditionals)))
+  ([spec]
+   (-> (merge/deep-merge (default-config) (maybe-user-config) spec)
+       (apply-conditionals))))


### PR DESCRIPTION
use :merge-aliases or :reset-aliases to choose aliases which are submaps that will be merged with configuration

The idea is to make it possible to configure several ways to run Clay,
and easily switch between them.