### PR TITLE
inline tex in span, block displayMode

### DIFF
--- a/notebooks/clay_book/examples.clj
+++ b/notebooks/clay_book/examples.clj
@@ -177,7 +177,19 @@ scittle.core.eval_string('(.log js/console 123)')
 ;; LaTeX formulae are supported as well.
 
 (kind/md
- "Let $x=9$. Then $$x+11=20$$")
+ "Let $x=9$. Then $x+11=20$")
+
+;; You can also put them in your comments:
+
+;; ```
+;; ;; $$e^{i\\pi} + 1 = 0$$
+;; ```
+;; $$e^{i\\pi} + 1 = 0$$
+
+;; ```
+;; ;; Or inline $e^{i\\pi} + 1 = 0$
+;; ```
+;; Or inline  $e^{i\\pi} + 1 = 0$
 
 ;; ## TeX
 

--- a/notebooks/index.clj
+++ b/notebooks/index.clj
@@ -1058,6 +1058,22 @@
 
 ;; Markdown styling is not currently handled when rendering direct to HTML.
 
+;; ### Markdown Math Equations
+
+;; `$$` at the start of a line is for centered blocks
+
+;; ```
+;; ;; $$e^{i\\pi} + 1 = 0$$
+;; ```
+;; $$e^{i\\pi} + 1 = 0$$
+
+;; `$` anywhere in the comment is for inline
+
+;; ```
+;; ;; Or inline $e^{i\\pi} + 1 = 0$
+;; ```
+;; Or inline  $e^{i\\pi} + 1 = 0$
+
 ;; ## Varying Kindly options
 
 ;; (experimental)

--- a/src/scicloj/clay/v2/item.clj
+++ b/src/scicloj/clay/v2/item.clj
@@ -141,15 +141,13 @@
             in-vector
             (str/join "\n"))})
 
-(defn katex-hiccup
-  ([s] (katex-hiccup s false))
-  ([s displayMode]
-   [:span
-    [:script
-     (format
-       "katex.render(%s, document.currentScript.parentElement, {displayMode: %s, throwOnError: false});"
-       (jso/write-json-str s)
-       (str (boolean displayMode)))]]))
+(defn katex-hiccup [s displayMode]
+  [:span
+   [:script
+    (format
+      "katex.render(%s, document.currentScript.parentElement, {displayMode: %s, throwOnError: false});"
+      (jso/write-json-str s)
+      (str (boolean displayMode)))]])
 
 (defn tex [text]
   {:md     (->> text

--- a/src/scicloj/clay/v2/prepare.clj
+++ b/src/scicloj/clay/v2/prepare.clj
@@ -100,7 +100,7 @@
                    (claywalk/postwalk (fn [form]
                                         (cond
                                           (vector-that-starts-with? form :span.formula)
-                                          (item/katex-hiccup (second form))
+                                          (item/katex-hiccup (second form) false)
                                           (vector-that-starts-with? form :figure.formula)
                                           (item/katex-hiccup (second form) true)
                                           :else form)))))))


### PR DESCRIPTION
Fix `$math$` should be inline.
Fix `$$math$$` should be a block.
Note that `kind/tex` will be centered now, which is a small change that matches Quarto behavior.
[#clay-dev > backslashes in &#96;TeX&#96;](https://clojurians.zulipchat.com/#narrow/channel/422115-clay-dev/topic/backslashes.20in.20.60TeX.60/with/540611045)