### PR TITLE
fix: (ClassCastException) at babashka.fs/u+wx

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -16,7 +16,7 @@
         org.scicloj/kind-portal {:mvn/version "1-beta3"}
         org.clojure/tools.reader {:mvn/version "1.5.2"}
         com.nextjournal/beholder {:mvn/version "1.0.2"}
-        babashka/fs {:mvn/version "0.5.25"}
+        babashka/fs {:mvn/version "0.5.27"}
         org.scicloj/kindly-render {:mvn/version "0.1.5-alpha"}
         io.github.tonsky/clojure-plus {:mvn/version "1.4.0"}
         org.clj-commons/pretty {:mvn/version "3.5.0"}}


### PR DESCRIPTION
Babashka/fs had a bug in the used v05.25 version that caused exceptions when `u+wx` was used, preventing document building (at least on my mac)

Fixes: #305

I tested successfully as follows:

## Locally building a SNAPSHOT

```sh
clojure -T:build ci :snapshot true
; ...  target/org.scicloj/clay-2.0.0-SNAPSHOT.jar
mvn install:install-file -Dfile=target/org.scicloj/clay-2.0.0-SNAPSHOT.jar
```

## Use SNAPSHOT

```edn
{;;...
  :docs
    ;; Build docs and exit via
    ;; clojure -M:dev:docs -r
    ;;
    ;; Build docs and watch via
    ;; clojure -M:dev:docs
  {:main-opts ["-m" "scicloj.clay.v2.main"]
   :extra-deps {org.scicloj/clay {:mvn/version "2.0.0-SNAPSHOT"}}}
;;...
}
```

## Manual test

Both `clojure -M:dev:docs` and `clojure -M:dev:docs -r` work
