### PR TITLE
fix content type for cljs files Scittle

### DIFF
--- a/src/scicloj/clay/v2/server.clj
+++ b/src/scicloj/clay/v2/server.clj
@@ -31,8 +31,8 @@
   (loop [port default-port]
     ;; Check if the port is free:
     ;; (https://codereview.stackexchange.com/a/31591)
-    (or (try (do (.close (ServerSocket. port))
-                 port)
+    (or (try (.close (ServerSocket. port))
+             port
              (catch Exception e nil))
         (recur (inc port)))))
 
@@ -231,7 +231,7 @@
                             slurp
                             (wrap-html state))
                         f)
-             :headers (when-let [t (mime-type/ext-mime-type uri)]
+             :headers (when-let [t (mime-type/ext-mime-type uri {"cljs" "text/plain"})]
                         {"Content-Type" t})
              :status  200}
             (case [request-method uri]


### PR DESCRIPTION
Minor change should be safe to merge.
On Firefox, a warning is shown otherwise when loading cljs files using Scittle.
@daslu 

Not urgent, as doesn't change anything just gets rid of a warning in a special case.