### PR TITLE
include trailing comments in code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## PENDING
+- capture trailing comments in code blocks
+
 ## [2.0.9 - 2026-02-01]
 - updated deps: Kindly, tools.reader
 - set `kindly/*prefer-kinds*` when rendering to let functions know they would rather return kindly-annotated values rather than launch external tools


### PR DESCRIPTION
Some discussion here
[#clay-dev > Display last code comment in code block?](https://clojurians.zulipchat.com/#narrow/channel/422115-clay-dev/topic/Display.20last.20code.20comment.20in.20code.20block.3F/with/572239156)
and previously in other topics