### PR TITLE
downgrade ring-defaults to be compatible with ring version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
         org.antlr/antlr4-runtime {:mvn/version "4.7.1"}
         http-kit/http-kit {:mvn/version "2.8.0"}
         ring/ring {:mvn/version "1.14.1"}
-        ring/ring-defaults {:mvn/version "0.7.0"}
+        ring/ring-defaults {:mvn/version "0.6.0"}
         metosin/muuntaja {:mvn/version "0.6.11"}
         io.github.nextjournal/markdown {:mvn/version "0.6.157"}
         hiccup/hiccup {:mvn/version "2.0.0-RC5"}


### PR DESCRIPTION
Context:
ring/ring-defaults 0.7.0 is not compatible with the ring/ring 1.14.1 that Clay claims to depend on, because it uses the content-length middleware, which has only been added to ring in v. 1.15.0 (see https://github.com/ring-clojure/ring/blob/master/CHANGELOG.md#1150-beta1-2025-07-22).

Fix:
Downgrade ring-defaults back to 0.6.0, before it added the wrap-content-length middleware.