### PR TITLE
Include class on svg img

### DIFF
--- a/src/scicloj/clay/v2/prepare.clj
+++ b/src/scicloj/clay/v2/prepare.clj
@@ -77,8 +77,7 @@
                                :keys [item-class script]}]
   (-> hiccup
       (add-class-to-hiccup item-class)
-      (merge-attrs (some-> (:kindly/options item)
-                           (select-keys [:style :class])))
+      (merge-attrs (some-> item :kindly/options (select-keys [:style :class :id])))
       (cond-> script
         (conj script))))
 
@@ -490,13 +489,17 @@
             (= :svg (first value)))
      (let [[svg-path relative-path] (files/next-file! context "image" value ".svg")
            class (when (-> value second map?)
-                   (-> value second :class))]
+                   (-> value second :class))
+           {:keys [id]} options]
        (->> (ensure-svg-xmlns value)
             (hiccup/html {:mode :xml})
             (spit svg-path))
        {:md (str "![" (:caption options) "](" relative-path ")"
-                 (when (and class (-> context :format first #{:quarto}))
-                   (str "{" (str/join " " (map #(str "." %) (str/split class #"\s+"))) "}")))})
+                 (when (and (or id class) (-> context :format first #{:quarto}))
+                   (str "{" (str/join " "
+                                      (concat (when id [(str "#" id)])
+                                              (map #(str "." %) (str/split class #"\s+"))))
+                        "}")))})
      (let [*deps (atom
                   (-> context
                       :kindly/options

--- a/src/scicloj/clay/v2/prepare.clj
+++ b/src/scicloj/clay/v2/prepare.clj
@@ -477,7 +477,7 @@
               (contains? (second hiccup) :xmlns))
         hiccup
         (update-in hiccup [1] assoc :xmlns "http://www.w3.org/2000/svg"))
-      (into [(first hiccup) {:xlmns "http://www.w3.org/2000/svg"}] (rest hiccup)))
+      (into [(first hiccup) {:xmlns "http://www.w3.org/2000/svg"}] (rest hiccup)))
     hiccup))
 
 (add-preparer!
@@ -593,5 +593,3 @@
 (add-preparer-from-value-fn!
  :kind/highcharts
  #'item/highcharts)
-
-

--- a/src/scicloj/clay/v2/prepare.clj
+++ b/src/scicloj/clay/v2/prepare.clj
@@ -12,7 +12,8 @@
             [hiccup.core :as hiccup]
             [scicloj.kindly.v4.api :as kindly]
             [scicloj.kindly.v4.kind :as kind]
-            [scicloj.kindly-render.shared.jso :as jso]))
+            [scicloj.kindly-render.shared.jso :as jso]
+            [clojure.string :as str]))
 
 (def *kind->preparer
   (atom {}))
@@ -487,12 +488,15 @@
    (if (and (item/static? context)
             (vector? value)
             (= :svg (first value)))
-     (let [[svg-path relative-path]
-           (files/next-file! context "image" value ".svg")]
+     (let [[svg-path relative-path] (files/next-file! context "image" value ".svg")
+           class (when (-> value second map?)
+                   (-> value second :class))]
        (->> (ensure-svg-xmlns value)
             (hiccup/html {:mode :xml})
             (spit svg-path))
-       {:md (str "![" (:caption options) "](" relative-path ")")})
+       {:md (str "![" (:caption options) "](" relative-path ")"
+                 (when class
+                   (str "{" (str/join " " (map #(str "." %) (str/split class #"\s+"))) "}")))})
      (let [*deps (atom
                   (-> context
                       :kindly/options

--- a/src/scicloj/clay/v2/prepare.clj
+++ b/src/scicloj/clay/v2/prepare.clj
@@ -495,7 +495,7 @@
             (hiccup/html {:mode :xml})
             (spit svg-path))
        {:md (str "![" (:caption options) "](" relative-path ")"
-                 (when class
+                 (when (and class (-> context :format first #{:quarto}))
                    (str "{" (str/join " " (map #(str "." %) (str/split class #"\s+"))) "}")))})
      (let [*deps (atom
                   (-> context


### PR DESCRIPTION
When using `static` SVG images,
transferring the class helps for example with Plotje.
Civitas wishes to style plotje based on the class for both inline and img static embedding.